### PR TITLE
Added http to the list of supported rtt_types

### DIFF
--- a/check_cisco_ip_sla.py
+++ b/check_cisco_ip_sla.py
@@ -377,6 +377,17 @@ class CiscoIpSlaChecker:
                 # rttMonLatestRttOperSense (2)
                 # See http://www.circitor.fr/Mibs/Html/CISCO-RTTMON-TC-MIB.php#RttResponseSense
                 self.rtt_dict[rtt_entry]["latest_sense"] = int(item.value)
+                if item.value == "14":
+                    self.rtt_dict[rtt_entry]["dns_query_error"] = True
+                    self.options.perf =False
+                else:
+                    self.rtt_dict[rtt_entry]["dns_query_error"] = False
+
+                if item.value == "15":
+                    self.rtt_dict[rtt_entry]["http_error"] = True
+                    self.options.perf =False
+                else:
+                    self.rtt_dict[rtt_entry]["http_error"] = False
 
         # Get Jitter specific data (See "-- LatestJitterOper Table" in MIB)
         self.print_msg(self.V_DEBUG, "Starting SNMP-walk for rttMonLatestJitterOperTable (.1.3.6.1.4.1.9.9.42.1.5.2.1)")
@@ -867,6 +878,12 @@ class CiscoIpSlaChecker:
                 elif self.rtt_dict[requested_entry]["over_thres_occurred"]:
                     failed_count += 1
                     messages.append("Threshold exceeded for SLA {0}".format(sla_description))
+                elif self.rtt_dict[requested_entry]["dns_query_error"]:
+                    failed_count += 1
+                    messages.append("DNS query error for SLA {0}".format(sla_description))
+                elif self.rtt_dict[requested_entry]["http_error"]:
+                    failed_count += 1
+                    messages.append("HTTP error for SLA {0}".format(sla_description))
                 else:
                     ok_count += 1
             else:

--- a/check_cisco_ip_sla.py
+++ b/check_cisco_ip_sla.py
@@ -379,13 +379,11 @@ class CiscoIpSlaChecker:
                 self.rtt_dict[rtt_entry]["latest_sense"] = int(item.value)
                 if item.value == "14":
                     self.rtt_dict[rtt_entry]["dns_query_error"] = True
-                    self.options.perf =False
                 else:
                     self.rtt_dict[rtt_entry]["dns_query_error"] = False
 
                 if item.value == "15":
                     self.rtt_dict[rtt_entry]["http_error"] = True
-                    self.options.perf =False
                 else:
                     self.rtt_dict[rtt_entry]["http_error"] = False
 
@@ -881,9 +879,11 @@ class CiscoIpSlaChecker:
                 elif self.rtt_dict[requested_entry]["dns_query_error"]:
                     failed_count += 1
                     messages.append("DNS query error for SLA {0}".format(sla_description))
+                    self.options.perf = False
                 elif self.rtt_dict[requested_entry]["http_error"]:
                     failed_count += 1
                     messages.append("HTTP error for SLA {0}".format(sla_description))
+                    self.options.perf = False
                 else:
                     ok_count += 1
             else:

--- a/check_cisco_ip_sla.py
+++ b/check_cisco_ip_sla.py
@@ -667,6 +667,7 @@ class CiscoIpSlaChecker:
             CiscoIpSlaChecker.get_rtt_type_id("echo"),
             CiscoIpSlaChecker.get_rtt_type_id("pathEcho"),
             CiscoIpSlaChecker.get_rtt_type_id("jitter"),
+            CiscoIpSlaChecker.get_rtt_type_id("http"),
         ]
         return rtt_type in supported_rtt_types
 


### PR DESCRIPTION
Hello,

Please consider these changes to be merged into the master. I need to check HTTP SLA. I've tried to simply add the "http" to the list of allowed rtt_types. Then I made a few tests:
Configuration:
~~~
ip sla 1
 http get http://1.2.3.4:6517/cgi-bin/somescript.exe
 tag TEST
 timeout 30000
ip sla schedule 1 life forever start-time now
ip sla 2
 http get http://ping.eu/img/ping_logo.gif
 tag TEST
 timeout 30000
ip sla schedule 2 life forever start-time now
ip sla 220
 icmp-echo 8.8.4.4 source-ip 6.3.10.90
ip sla schedule 220 life forever start-time now
~~~

Tests:
~~~
python check_cisco_ip_sla.py -H 10.10.10.3 -v 3 -u user -l authPriv -a SHA -A "somepass" -x AES -X "somepass" -m check -e 1 --perf
OK - 1 OK | 'rtt'=47ms
python check_cisco_ip_sla.py -H 10.10.10.3 -v 3 -u user -l authPriv -a SHA -A "somepass" -x AES -X "somepass" -m check -e 200 --perf
Unknown - SLA 200 does not exist
python check_cisco_ip_sla.py -H 10.10.10.3 -v 3 -u user -l authPriv -a SHA -A "somepass" -x AES -X "somepass" -m check -e 220 --perf 
OK - 1 OK | 'rtt'=1ms
python check_cisco_ip_sla.py -H 10.10.10.3 -v 3 -u user -l authPriv -a SHA -A "somepass" -x AES -X "somepass" -m check -e 1,2 --perf
OK - 2 OK | 'Failed%'=0.0%;50;100;0;100 'rtt 1'=48ms 'rtt 2'=134ms
python check_cisco_ip_sla.py -H 10.10.10.3 -v 3 -u user -l authPriv -a SHA -A "somepass" -x AES -X "somepass" -m check -e 1,220 --perf
Unknown - Checking multiple SLA entries is supported, but only if they are of the same type.
~~~
So it seems that http also should work pretty well, as far as I see.

Which other tests do you want me to do before you can merge it?