### PR TITLE
fix KeyError when checking CiscoIpSlaChecker.rtt_dict[requested_entry]

### DIFF
--- a/check_cisco_ip_sla.py
+++ b/check_cisco_ip_sla.py
@@ -879,13 +879,13 @@ class CiscoIpSlaChecker:
             sla_description = self.get_sla_description(requested_entry)
 
             if self.rtt_dict[requested_entry]["in_active_state"]:
-                if self.rtt_dict[requested_entry]["conn_lost_occurred"]:
+                if "conn_lost_occurred" in self.rtt_dict[requested_entry] and self.rtt_dict[requested_entry]["conn_lost_occurred"]:
                     failed_count += 1
                     messages.append("Connection lost for SLA {0}".format(sla_description))
-                elif self.rtt_dict[requested_entry]["timeout_occurred"]:
+                elif "timeout_occurred" in self.rtt_dict[requested_entry] and self.rtt_dict[requested_entry]["timeout_occurred"]:
                     failed_count += 1
                     messages.append("Timeout for SLA {0}".format(sla_description))
-                elif self.rtt_dict[requested_entry]["over_thres_occurred"]:
+                elif "over_thres_occurred" in self.rtt_dict[requested_entry] and self.rtt_dict[requested_entry]["over_thres_occurred"]:
                     failed_count += 1
                     messages.append("Threshold exceeded for SLA {0}".format(sla_description))
                 else:


### PR DESCRIPTION
this is a really quick fix for issue #12 

I did not research _why_ the expected keys are not in the dict, but simply ignoring them if they are not there seems enough to make it Work For Me™. I would kindly ask someone more familiar with the code to check out if this is not introducing side effects such as ignoring any warning / critical condition, I have only been able to test it briefly with an OK condition.