### PR TITLE
fix an error caused by not using the -p argument

### DIFF
--- a/check_cisco_ip_sla.py
+++ b/check_cisco_ip_sla.py
@@ -258,7 +258,7 @@ class CiscoIpSlaChecker:
         print(output)
 
     def create_snmp_session(self):
-        self.session = Session(
+        kwargs = dict(
             hostname=self.options.hostname,
             version=int(self.options.snmp_version),
             community=self.options.community,
@@ -270,6 +270,13 @@ class CiscoIpSlaChecker:
             privacy_password=self.options.priv_password,
             use_numeric=True,
         )
+
+        if self.options.auth_password is None:
+            kwargs.pop('auth_password')
+        if self.options.priv_password is None:
+            kwargs.pop('privacy_password')
+
+        self.session = Session(**kwargs)
 
     def add_status(self, status):
         """ Set the status only if it is more severe than the present status


### PR DESCRIPTION
When called with `-A <password>` instead of `-p <password>` the following error has been reported:

```
./check_cisco_ip_sla.py -H <IP addr> -v 3 -a SHA -A <USM auth password> -l authNoPriv -u <USM username> -m check -e 10 --perf
Traceback (most recent call last):
  File "/home/orbis/./check_cisco_ip_sla.py", line 956, in <module>
    result = checker.run()
  File "/home/orbis/./check_cisco_ip_sla.py", line 75, in run
    self.create_snmp_session()
  File "/home/orbis/./check_cisco_ip_sla.py", line 261, in create_snmp_session
    self.session = Session(
  File "/usr/lib/nagios/plugins/external/venv-check_cisco_ip_sla/lib/python3.9/site-packages/easysnmp/session.py", line 259, in __init__
    self.sess_ptr = interface.session_v3(
TypeError: argument 14 must be str, not None
```
Now one can use `-A` and/or `-X` without providing `-p`.